### PR TITLE
feat: 画像へのタグ付与・タグ検索機能の追加

### DIFF
--- a/src/app/app.component.ts
+++ b/src/app/app.component.ts
@@ -97,7 +97,7 @@ export class AppComponent implements AfterViewInit, OnDestroy {
     let fileContext = ImageFile.createEmpty('none_icon').toContext();
     fileContext.url = './assets/images/ic_account_circle_black_24dp_2x.png';
     let noneIconImage = ImageStorage.instance.add(fileContext);
-    ImageTag.create(noneIconImage.identifier, 'imagetag_none_icon').tag = 'default';
+    ImageTag.create(noneIconImage.identifier).tag = 'default';
 
     AudioPlayer.resumeAudioContext();
     PresetSound.dicePick = AudioStorage.instance.add('./assets/sounds/soundeffect-lab/shoulder-touch1.mp3').identifier;

--- a/src/app/app.component.ts
+++ b/src/app/app.component.ts
@@ -35,6 +35,7 @@ import { ModalService } from 'service/modal.service';
 import { PanelOption, PanelService } from 'service/panel.service';
 import { PointerDeviceService } from 'service/pointer-device.service';
 import { SaveDataService } from 'service/save-data.service';
+import { ImageTag } from '@udonarium/image-tag';
 
 @Component({
   selector: 'app-root',
@@ -96,6 +97,7 @@ export class AppComponent implements AfterViewInit, OnDestroy {
     let fileContext = ImageFile.createEmpty('none_icon').toContext();
     fileContext.url = './assets/images/ic_account_circle_black_24dp_2x.png';
     let noneIconImage = ImageStorage.instance.add(fileContext);
+    ImageTag.create(noneIconImage.identifier, 'imagetag_none_icon').tag = 'default';
 
     AudioPlayer.resumeAudioContext();
     PresetSound.dicePick = AudioStorage.instance.add('./assets/sounds/soundeffect-lab/shoulder-touch1.mp3').identifier;

--- a/src/app/app.component.ts
+++ b/src/app/app.component.ts
@@ -36,7 +36,6 @@ import { ModalService } from 'service/modal.service';
 import { PanelOption, PanelService } from 'service/panel.service';
 import { PointerDeviceService } from 'service/pointer-device.service';
 import { SaveDataService } from 'service/save-data.service';
-import { ImageTag } from '@udonarium/image-tag';
 
 @Component({
   selector: 'app-root',
@@ -99,10 +98,6 @@ export class AppComponent implements AfterViewInit, OnDestroy {
     let fileContext = ImageFile.createEmpty('none_icon').toContext();
     fileContext.url = './assets/images/ic_account_circle_black_24dp_2x.png';
     let noneIconImage = ImageStorage.instance.add(fileContext);
-    let noneIconImageTag = new ImageTag();
-    noneIconImageTag.imageIdentifier = noneIconImage.identifier;
-    noneIconImageTag.tag = 'default';
-    ImageTagList.instance.appendChild(noneIconImageTag);
 
     AudioPlayer.resumeAudioContext();
     PresetSound.dicePick = AudioStorage.instance.add('./assets/sounds/soundeffect-lab/shoulder-touch1.mp3').identifier;

--- a/src/app/app.component.ts
+++ b/src/app/app.component.ts
@@ -14,7 +14,6 @@ import { ObjectStore } from '@udonarium/core/synchronize-object/object-store';
 import { ObjectSynchronizer } from '@udonarium/core/synchronize-object/object-synchronizer';
 import { EventSystem, Network } from '@udonarium/core/system';
 import { DataSummarySetting } from '@udonarium/data-summary-setting';
-import { ImageTagList } from '@udonarium/image-tag-list';
 import { DiceBot } from '@udonarium/dice-bot';
 import { Jukebox } from '@udonarium/Jukebox';
 import { PeerCursor } from '@udonarium/peer-cursor';
@@ -76,7 +75,6 @@ export class AppComponent implements AfterViewInit, OnDestroy {
     this.pointerDeviceService.initialize();
 
     DataSummarySetting.instance.initialize();
-    ImageTagList.instance.initialize();
 
     let diceBot: DiceBot = new DiceBot('DiceBot');
     diceBot.initialize();

--- a/src/app/class/core/file-storage/file-archiver.ts
+++ b/src/app/class/core/file-storage/file-archiver.ts
@@ -7,7 +7,6 @@ import { AudioStorage } from './audio-storage';
 import { FileReaderUtil } from './file-reader-util';
 import { ImageStorage } from './image-storage';
 import { MimeType } from './mime-type';
-import {ImageTagList} from '../../image-tag-list';
 
 export class FileArchiver {
   private static _instance: FileArchiver
@@ -88,9 +87,7 @@ export class FileArchiver {
     if (file.type.indexOf('image/') < 0) return;
     console.log(file.name + ' type:' + file.type);
     if (2 * 1024 * 1024 < file.size) return;
-
-    let newImage = await ImageStorage.instance.addAsync(file);
-    ImageTagList.instance.pushTag(newImage.identifier);
+    await ImageStorage.instance.addAsync(file);
   }
 
   private async handleAudio(file: File) {

--- a/src/app/class/core/file-storage/image-storage.ts
+++ b/src/app/class/core/file-storage/image-storage.ts
@@ -20,6 +20,12 @@ export class ImageStorage {
     return images;
   }
 
+  getImagesByIdentifiers(identifiers: string[]): ImageFile[] {
+    return identifiers
+      .map(identifier => this.imageHash[identifier])
+      .filter(image => image);
+  }
+
   private lazyTimer: NodeJS.Timer;
 
   private constructor() {

--- a/src/app/class/core/file-storage/image-storage.ts
+++ b/src/app/class/core/file-storage/image-storage.ts
@@ -20,12 +20,6 @@ export class ImageStorage {
     return images;
   }
 
-  getImagesByIdentifiers(identifiers: string[]): ImageFile[] {
-    return identifiers
-      .map(identifier => this.imageHash[identifier])
-      .filter(image => image);
-  }
-
   private lazyTimer: NodeJS.Timer;
 
   private constructor() {
@@ -67,7 +61,6 @@ export class ImageStorage {
     if (this.update(image)) return this.imageHash[image.identifier];
     this.imageHash[image.identifier] = image;
     console.log('addNewFile()', image);
-
     return image;
   }
 

--- a/src/app/class/image-tag-list.ts
+++ b/src/app/class/image-tag-list.ts
@@ -16,7 +16,7 @@ export class ImageTagList extends ObjectNode implements InnerXml {
   }
 
   innerXml(): string {
-    return Array.from(this.identifiers)
+    return Array.from(new Set(this.identifiers))
       .map(identifier => ImageTag.getTag(identifier))
       .filter(imageTag => imageTag)
       .map(imageTag => imageTag.toXml())

--- a/src/app/class/image-tag-list.ts
+++ b/src/app/class/image-tag-list.ts
@@ -2,57 +2,20 @@ import { ImageTag } from './image-tag';
 import { SyncObject } from './core/synchronize-object/decorator';
 import { ObjectNode } from './core/synchronize-object/object-node';
 import { InnerXml, ObjectSerializer } from './core/synchronize-object/object-serializer';
+import { ObjectStore } from './core/synchronize-object/object-store';
 
 @SyncObject('image-tag-list')
 export class ImageTagList extends ObjectNode implements InnerXml {
-  // todo:シングルトン化するのは妥当？
-  private static _instance: ImageTagList;
-  static get instance(): ImageTagList {
-    if (!ImageTagList._instance) {
-      ImageTagList._instance = new ImageTagList('ImageTagList');
-      ImageTagList._instance.initialize();
-    }
-    return ImageTagList._instance;
+  // GameObject Lifecycle
+  onStoreAdded() {
+    super.onStoreAdded();
+    ObjectStore.instance.remove(this); // ObjectStoreには登録しない
   }
 
-  private imageTagHash: { [imageIdentifier: string]: ImageTag } = {};
-
-  getTags(searchWords: string[]): ImageTag[] {
-    return (this.children as ImageTag[]).filter(tag => tag.containsWords(searchWords));
-  }
-
-  getTag(imageIdentifier: string): ImageTag {
-    const imageTag = this.imageTagHash[imageIdentifier];
-    return imageTag ? imageTag : null;
-  }
-
-  add(object: ImageTag) {
-    let imageTag = this.getTag(object.imageIdentifier);
-
-    if (imageTag) {
-      imageTag.tag += ' ' + object.tag;
-      object.destroy();
-    } else {
-      imageTag = object;
-      this.imageTagHash[object.imageIdentifier] = object;
-      this.appendChild(object);
-    }
-
-    return imageTag;
-  }
-
-  parseInnerXml(element: Element) {
-    // XMLからの新規作成を許可せず、既存のオブジェクトを更新する
-    const context = ImageTagList.instance.toContext();
-    context.syncData = this.toContext().syncData;
-    ImageTagList.instance.apply(context);
-    ImageTagList.instance.update();
-
-    for (let i = 0; i < element.children.length; i++) {
-      const child = ObjectSerializer.instance.parseXml(element.children[i]);
-      if (child instanceof ImageTag) ImageTagList.instance.add(child);
-    }
-
-    this.destroy();
+  innerXml(): string {
+    return ObjectStore.instance
+      .getObjects<ImageTag>(ImageTag)
+      .map(object => object.toXml())
+      .join();
   }
 }

--- a/src/app/class/image-tag-list.ts
+++ b/src/app/class/image-tag-list.ts
@@ -17,7 +17,7 @@ export class ImageTagList extends ObjectNode implements InnerXml {
 
   innerXml(): string {
     return Array.from(new Set(this.identifiers))
-      .map(identifier => ImageTag.getTag(identifier))
+      .map(identifier => ImageTag.get(identifier))
       .filter(imageTag => imageTag)
       .map(imageTag => imageTag.toXml())
       .join('');

--- a/src/app/class/image-tag-list.ts
+++ b/src/app/class/image-tag-list.ts
@@ -1,5 +1,5 @@
 import { ImageTag } from './image-tag';
-import { SyncObject, SyncVar } from './core/synchronize-object/decorator';
+import { SyncObject } from './core/synchronize-object/decorator';
 import { ObjectNode } from './core/synchronize-object/object-node';
 import { InnerXml } from './core/synchronize-object/object-serializer';
 import { PeerCursor } from './peer-cursor';
@@ -39,32 +39,33 @@ export class ImageTagList extends ObjectNode implements InnerXml {
     return null;
   }
 
-    pushTag(ide:string ,newtag:string = PeerCursor.myCursor.name ) :ImageTag {
-        let retTag =this.getTagFromIdentifier(ide);
+  pushTag(imageIdentifier: string, newtag: string = PeerCursor.myCursor.name): ImageTag {
+    let imageTag = this.getTagFromIdentifier(imageIdentifier);
 
-        if(retTag == null) {
-            retTag = new ImageTag();
-            retTag.imageIdentifier = ide;
-            retTag.tag = newtag;
-            this.appendChild(retTag);
-            return retTag;
-        }
-
-        if(retTag.tag != newtag) {
-            retTag.tag = newtag;
-        }
-        return retTag;
+    if (!imageTag) {
+      imageTag = new ImageTag();
+      imageTag.imageIdentifier = imageIdentifier;
+      imageTag.tag = newtag;
+      imageTag.initialize();
+      this.appendChild(imageTag);
+      return imageTag;
     }
 
-    innerXml(): string { return ''; }
-
-    parseInnerXml(element: Element) {
-      // XMLからの新規作成を許可せず、既存のオブジェクトを更新する
-      let context = ImageTagList.instance.toContext();
-      context.syncData = this.toContext().syncData;
-      ImageTagList.instance.apply(context);
-      ImageTagList.instance.update();
-  
-      this.destroy();
+    if (imageTag.tag !== newtag) {
+      imageTag.tag = newtag;
     }
+    return imageTag;
+  }
+
+  innerXml(): string { return ''; }
+
+  parseInnerXml(element: Element) {
+    // XMLからの新規作成を許可せず、既存のオブジェクトを更新する
+    const context = ImageTagList.instance.toContext();
+    context.syncData = this.toContext().syncData;
+    ImageTagList.instance.apply(context);
+    ImageTagList.instance.update();
+
+    this.destroy();
+  }
 }

--- a/src/app/class/image-tag-list.ts
+++ b/src/app/class/image-tag-list.ts
@@ -6,36 +6,38 @@ import { PeerCursor } from './peer-cursor';
 
 @SyncObject('ImageTagList')
 export class ImageTagList extends ObjectNode implements InnerXml {
-    // todo:シングルトン化するのは妥当？
-    private static _instance: ImageTagList;
-    static get instance(): ImageTagList {
-        if (!ImageTagList._instance) {
-        ImageTagList._instance = new ImageTagList('ImageTagList');
-        ImageTagList._instance.initialize();
-        }
-        return ImageTagList._instance;
+  // todo:シングルトン化するのは妥当？
+  private static _instance: ImageTagList;
+  static get instance(): ImageTagList {
+    if (!ImageTagList._instance) {
+      ImageTagList._instance = new ImageTagList('ImageTagList');
+      ImageTagList._instance.initialize();
+    }
+    return ImageTagList._instance;
+  }
+
+  getTagsByWords(searchWords: string[]): ImageTag[] {
+    const resultTags: ImageTag[] = [];
+
+    for (const target of this.children as ImageTag[]) {
+      if (target.containsWords(searchWords)) {
+        resultTags.push(target);
+      }
     }
 
-    getMatchTags(searchWord: string) :ImageTag[] {
-        let resultTags: ImageTag[] = [];
+    return resultTags;
+  }
 
-        for(let target of this.imageTags) {
-            if(target.isContainsWord(searchWord)) {
-                resultTags.push(target);
-            }
-        }
-
-        return resultTags;
+  getTagFromIdentifier(imageIdentifier: string): ImageTag {
+    for (const target of this.children as ImageTag[]) {
+      if (target.imageIdentifier === imageIdentifier) {
+        return target;
+      }
     }
 
-    getTagFromIdentifier(ide:string) :ImageTag {
-        for(let target of this.imageTags) {
-            if(target.imageIdentifier == ide) return target;
-        }
-
-        console.log('NotFound Target ImageTag from ImageTagList',ide);
-        return null;
-    }
+    console.log('NotFound Target ImageTag from ImageTagList', imageIdentifier);
+    return null;
+  }
 
     pushTag(ide:string ,newtag:string = PeerCursor.myCursor.name ) :ImageTag {
         let retTag =this.getTagFromIdentifier(ide);

--- a/src/app/class/image-tag-list.ts
+++ b/src/app/class/image-tag-list.ts
@@ -1,11 +1,14 @@
 import { ImageTag } from './image-tag';
 import { SyncObject } from './core/synchronize-object/decorator';
 import { ObjectNode } from './core/synchronize-object/object-node';
-import { InnerXml, ObjectSerializer } from './core/synchronize-object/object-serializer';
+import { InnerXml } from './core/synchronize-object/object-serializer';
 import { ObjectStore } from './core/synchronize-object/object-store';
+import { ImageFile } from './core/file-storage/image-file';
 
 @SyncObject('image-tag-list')
 export class ImageTagList extends ObjectNode implements InnerXml {
+  private identifiers: string[] = [];
+
   // GameObject Lifecycle
   onStoreAdded() {
     super.onStoreAdded();
@@ -13,9 +16,18 @@ export class ImageTagList extends ObjectNode implements InnerXml {
   }
 
   innerXml(): string {
-    return ObjectStore.instance
-      .getObjects<ImageTag>(ImageTag)
-      .map(object => object.toXml())
-      .join();
+    return Array.from(this.identifiers)
+      .map(identifier => ImageTag.getTag(identifier))
+      .filter(imageTag => imageTag)
+      .map(imageTag => imageTag.toXml())
+      .join('');
+  }
+
+  static create(images: ImageFile[]): ImageTagList {
+    const imageTagList = new ImageTagList();
+
+    imageTagList.identifiers = images.map(image => image.identifier);
+
+    return imageTagList;
   }
 }

--- a/src/app/class/image-tag.ts
+++ b/src/app/class/image-tag.ts
@@ -3,17 +3,13 @@ import { ObjectNode } from './core/synchronize-object/object-node';
 
 @SyncObject('image-tag')
 export class ImageTag extends ObjectNode {
-    @SyncVar() imageIdentifier: string = '';
-    @SyncVar() isSave: boolean = false;
+  @SyncVar() imageIdentifier: string = '';
+  @SyncVar() isSave: boolean = false;
 
-    get tag():string {return <string>this.value; }
+  get tag(): string { return this.value as string; }
+  set tag(tag: string) { this.value = tag; }
 
-    set tag(tag:string) { this.value = tag; }
-
-    isContainsWord(word: string) :boolean {
-        if(this.tag.indexOf(word) == -1) { return false; }
-        else {return true; }
-    }
-
-    
+  containsWords(words: string[]): boolean {
+    return words.every(word => this.tag.indexOf(word) >= 0);
+  }
 }

--- a/src/app/class/image-tag.ts
+++ b/src/app/class/image-tag.ts
@@ -9,8 +9,6 @@ export class ImageTag extends ObjectNode {
   @SyncVar() imageIdentifier: string = '';
   @SyncVar() tag: string = '';
 
-  get image(): ImageFile { return ImageStorage.instance.get(this.imageIdentifier); }
-
   containsWords(words: string[]): boolean {
     return words.every(word => this.tag.indexOf(word) >= 0);
   }
@@ -19,11 +17,11 @@ export class ImageTag extends ObjectNode {
     return ObjectStore.instance
       .getObjects<ImageTag>(ImageTag)
       .filter(tag => tag.containsWords(searchWords))
-      .map(tag => tag.image)
+      .map(tag => ImageStorage.instance.get(tag.imageIdentifier))
       .filter(image => image);
   }
 
-  static getTag(imageIdentifier: string): ImageTag {
+  static get(imageIdentifier: string): ImageTag {
     return ObjectStore.instance.get<ImageTag>(`imagetag_${imageIdentifier}`);
   }
 
@@ -38,7 +36,7 @@ export class ImageTag extends ObjectNode {
 
   parseInnerXml(element: Element) {
     // 既存のオブジェクトを更新する
-    let imageTag = ImageTag.getTag(this.imageIdentifier);
+    let imageTag = ImageTag.get(this.imageIdentifier);
     if (!imageTag) imageTag = ImageTag.create(this.imageIdentifier);
     const context = imageTag.toContext();
     context.syncData = this.toContext().syncData;

--- a/src/app/class/image-tag.ts
+++ b/src/app/class/image-tag.ts
@@ -4,12 +4,21 @@ import { ObjectNode } from './core/synchronize-object/object-node';
 @SyncObject('image-tag')
 export class ImageTag extends ObjectNode {
   @SyncVar() imageIdentifier: string = '';
-  @SyncVar() isSave: boolean = false;
 
   get tag(): string { return this.value as string; }
   set tag(tag: string) { this.value = tag; }
 
   containsWords(words: string[]): boolean {
     return words.every(word => this.tag.indexOf(word) >= 0);
+  }
+
+  static create(imageIdentifier: string, tag: string) {
+    const object: ImageTag = new ImageTag();
+
+    object.imageIdentifier = imageIdentifier;
+    object.tag = tag;
+
+    object.initialize();
+    return object;
   }
 }

--- a/src/app/class/image-tag.ts
+++ b/src/app/class/image-tag.ts
@@ -1,18 +1,65 @@
 import { SyncObject, SyncVar } from './core/synchronize-object/decorator';
 import { ObjectNode } from './core/synchronize-object/object-node';
+import { ObjectStore } from './core/synchronize-object/object-store';
+import { ImageFile } from './core/file-storage/image-file';
+import { ImageStorage } from './core/file-storage/image-storage';
 
 @SyncObject('image-tag')
 export class ImageTag extends ObjectNode {
   @SyncVar() imageIdentifier: string = '';
 
+  private static map: Map<string, string> = new Map<string, string>();
+
   get tag(): string { return this.value as string; }
   set tag(tag: string) { this.value = tag; }
+
+  get image(): ImageFile { return ImageStorage.instance.get(this.imageIdentifier); }
+
+  // GameObject Lifecycle
+  onStoreAdded() {
+    super.onStoreAdded();
+    if (ImageTag.map.has(this.imageIdentifier)) {
+      const imageTag = ImageTag.getTag(this.imageIdentifier);
+      if (imageTag) imageTag.destroy();
+    }
+    ImageTag.map.set(this.imageIdentifier, this.identifier);
+  }
+
+  onStoreRemoved() {
+    super.onStoreRemoved();
+    ImageTag.map.delete(this.imageIdentifier);
+  }
 
   containsWords(words: string[]): boolean {
     return words.every(word => this.tag.indexOf(word) >= 0);
   }
 
+  static searchImages(searchWords: string[]): ImageFile[] {
+    return ObjectStore.instance
+      .getObjects<ImageTag>(ImageTag)
+      .filter(tag => tag.containsWords(searchWords))
+      .map(tag => tag.image)
+      .filter(image => image);
+  }
+
+  static getTag(imageIdentifier: string): ImageTag {
+    const identifier = ImageTag.map.get(imageIdentifier);
+    if (identifier != null && ObjectStore.instance.get(identifier)) return ObjectStore.instance.get<ImageTag>(identifier);
+    const imageTags = ObjectStore.instance.getObjects<ImageTag>(ImageTag);
+    for (const imageTag of imageTags) {
+      if (imageTag.imageIdentifier === imageIdentifier) {
+        ImageTag.map.set(imageIdentifier, imageTag.identifier);
+        return imageTag;
+      }
+    }
+    return null;
+  }
+
   static create(imageIdentifier: string, tag: string) {
+    if (ImageTag.getTag(imageIdentifier)) {
+      console.warn(`ImageTag: ${imageIdentifier} is already created.`);
+      return ImageTag.getTag(imageIdentifier);
+    }
     const object: ImageTag = new ImageTag();
 
     object.imageIdentifier = imageIdentifier;

--- a/src/app/class/image-tag.ts
+++ b/src/app/class/image-tag.ts
@@ -55,15 +55,14 @@ export class ImageTag extends ObjectNode {
     return null;
   }
 
-  static create(imageIdentifier: string, tag: string) {
+  static create(imageIdentifier: string, identifier?: string) {
     if (ImageTag.getTag(imageIdentifier)) {
       console.warn(`ImageTag: ${imageIdentifier} is already created.`);
       return ImageTag.getTag(imageIdentifier);
     }
-    const object: ImageTag = new ImageTag();
+    const object: ImageTag = identifier ? new ImageTag(identifier) : new ImageTag();
 
     object.imageIdentifier = imageIdentifier;
-    object.tag = tag;
 
     object.initialize();
     return object;

--- a/src/app/component/file-selecter/file-selecter.component.css
+++ b/src/app/component/file-selecter/file-selecter.component.css
@@ -14,3 +14,16 @@
 .empty button {
   height: 100px;
 }
+
+.sticky-top {
+  padding: 5px;
+  position: sticky;
+  top: 0;
+  background-color: rgba(240, 218, 189, 0.8);
+  border-top: 1px dotted #666;
+  border-bottom: 1px dotted #666;
+}
+
+.sticky-top input {
+  width: calc(100% - 50px);
+}

--- a/src/app/component/file-selecter/file-selecter.component.html
+++ b/src/app/component/file-selecter/file-selecter.component.html
@@ -1,7 +1,6 @@
-<div id="search">
-  検索： <input [(ngModel)]="searchWord" placeholder="部分一致で検索 スペース区切りで複数指定" />
+<div class="sticky-top">
+  検索: <input [(ngModel)]="searchWord" placeholder="部分一致で検索 スペース区切りで複数指定" />
 </div>
-<hr/>
 <div id="file-list">
   <span class="empty" *ngIf="isAllowedEmpty">
     <button (click)="onSelectedFile(empty)">画像なし</button>

--- a/src/app/component/file-selecter/file-selecter.component.html
+++ b/src/app/component/file-selecter/file-selecter.component.html
@@ -1,5 +1,5 @@
 <div id="search">
-  検索：  <input [(ngModel)]=" searchWord"  placeholder="部分一致で検索" />   <button (click)="searchImageFromTag()">検索</button>
+  検索： <input [(ngModel)]="searchWord" placeholder="部分一致で検索 スペース区切りで複数指定" />
 </div>
 <hr/>
 <div id="file-list">

--- a/src/app/component/file-selecter/file-selecter.component.ts
+++ b/src/app/component/file-selecter/file-selecter.component.ts
@@ -21,7 +21,7 @@ import { ImageTagList } from '@udonarium/image-tag-list';
   changeDetection: ChangeDetectionStrategy.OnPush
 })
 export class FileSelecterComponent implements OnInit, OnDestroy, AfterViewInit {
-  searchWord: string = 'default';
+  searchWord: string = '';
 
   private _searchWord: string;
   private _searchWords: string[];
@@ -35,10 +35,11 @@ export class FileSelecterComponent implements OnInit, OnDestroy, AfterViewInit {
 
   @Input() isAllowedEmpty: boolean = false;
   get images(): ImageFile[] {
-    const identifiers = ImageTagList.instance
-      .getTagsByWords(this.searchWords)
-      .map(imageTag => imageTag.imageIdentifier);
-    return ImageStorage.instance.getImagesByIdentifiers(identifiers);
+    if (this.searchWords.length < 1) return ImageStorage.instance.images;
+    return ImageTagList.instance
+      .getTags(this.searchWords)
+      .map(imageTag => ImageStorage.instance.get(imageTag.imageIdentifier))
+      .filter(image => image);
   }
   get empty(): ImageFile { return ImageFile.Empty; }
 

--- a/src/app/component/file-selecter/file-selecter.component.ts
+++ b/src/app/component/file-selecter/file-selecter.component.ts
@@ -12,7 +12,7 @@ import { ImageStorage } from '@udonarium/core/file-storage/image-storage';
 import { EventSystem, Network } from '@udonarium/core/system';
 import { ModalService } from 'service/modal.service';
 import { PanelService } from 'service/panel.service';
-import { ImageTagList } from '@udonarium/image-tag-list';
+import { ImageTag } from '@udonarium/image-tag';
 
 @Component({
   selector: 'file-selector',
@@ -36,10 +36,7 @@ export class FileSelecterComponent implements OnInit, OnDestroy, AfterViewInit {
   @Input() isAllowedEmpty: boolean = false;
   get images(): ImageFile[] {
     if (this.searchWords.length < 1) return ImageStorage.instance.images;
-    return ImageTagList.instance
-      .getTags(this.searchWords)
-      .map(imageTag => ImageStorage.instance.get(imageTag.imageIdentifier))
-      .filter(image => image);
+    return ImageTag.searchImages(this.searchWords);
   }
   get empty(): ImageFile { return ImageFile.Empty; }
 

--- a/src/app/component/file-storage/file-storage.component.css
+++ b/src/app/component/file-storage/file-storage.component.css
@@ -19,9 +19,18 @@
 }
 
 .image {
+  display: inline-block;
   font-size: 0;
+  padding: 2px;
+  border: transparent 2px solid;
+  border-top: transparent 6px solid;
 }
 
 .image img {
   vertical-align: bottom;
+}
+
+.selected {
+  border: 2px dotted #666;
+  border-top: 6px solid #444;
 }

--- a/src/app/component/file-storage/file-storage.component.css
+++ b/src/app/component/file-storage/file-storage.component.css
@@ -8,6 +8,7 @@
   font: 24px bold 'Vollkorn';
   color: #444;
   cursor: pointer;
+  margin-bottom: 5px;
 }
 
 .large-font {
@@ -33,4 +34,17 @@
 .selected {
   border: 2px dotted #666;
   border-top: 6px solid #444;
+}
+
+.sticky-top {
+  padding: 5px;
+  position: sticky;
+  top: 0;
+  background-color: rgba(240, 218, 189, 0.8);
+  border-top: 1px dotted #666;
+  border-bottom: 1px dotted #666;
+}
+
+.sticky-top input {
+  width: calc(100% - 50px);
 }

--- a/src/app/component/file-storage/file-storage.component.html
+++ b/src/app/component/file-storage/file-storage.component.html
@@ -10,14 +10,14 @@
       <br>１ファイルにつき2MBまで</div>
   </div>
 </label>
-<hr/>
-<div id="search">
-  検索： <input [(ngModel)]="searchWord" placeholder="部分一致で検索 スペース区切りで複数指定" />
+<div class="sticky-top">
+  <div>
+    検索: <input [(ngModel)]="searchWord" placeholder="部分一致で検索 スペース区切りで複数指定" />
+  </div>
+  <div>
+    タグ: <input [(ngModel)]="selectedTag" placeholder="タグ名" [attr.disabled]="isSelected ? null : ''" />
+  </div>
 </div>
-<div>
-  選択した画像のタグ： <input [(ngModel)]="selectedTag" placeholder="スペース区切りで複数タグ名" [attr.disabled]="isSelected ? null : ''" />
-</div>
-<hr/>
 <div id="file-list">
   <div *ngFor="let file of images" [ngClass]="{ image: true, selected: selectedFile === file }" >
     <img *ngIf="0 < file.url.length" [src]="file.url | safe: 'resourceUrl'" [alt]="file.name" height="120" (click)="onSelectedFile(file)">

--- a/src/app/component/file-storage/file-storage.component.html
+++ b/src/app/component/file-storage/file-storage.component.html
@@ -14,13 +14,13 @@
 <div id="search">
   検索： <input [(ngModel)]="searchWord" placeholder="部分一致で検索 スペース区切りで複数指定" />
 </div>
-<div id="edit-tag">
-  選択した画像のタグ： <input [(ngModel)]="selectedTag" placeholder="スペース区切りで複数タグ名" />
+<div>
+  選択した画像のタグ： <input [(ngModel)]="selectedTag" placeholder="スペース区切りで複数タグ名" [attr.disabled]="isSelected ? null : ''" />
 </div>
 <hr/>
 <div id="file-list">
-  <span *ngFor="let file of images" class="image">
+  <div *ngFor="let file of images" [ngClass]="{ image: true, selected: selectedFile === file }" >
     <img *ngIf="0 < file.url.length" [src]="file.url | safe: 'resourceUrl'" [alt]="file.name" height="120" (click)="onSelectedFile(file)">
     <img *ngIf="file.url.length <= 0" src="assets/images/loading.gif" alt="{{file.name}}">
-  </span>
+  </div>
 </div>

--- a/src/app/component/file-storage/file-storage.component.html
+++ b/src/app/component/file-storage/file-storage.component.html
@@ -15,7 +15,7 @@
   検索： <input [(ngModel)]="searchWord" placeholder="部分一致で検索 スペース区切りで複数指定" />
 </div>
 <div id="edit-tag">
-  選択した画像のタグ： <input [(ngModel)]="editTag" placeholder="スペース区切りで複数タグ名" /> <button id="change-tag-button" (click)="changeTag()" [disabled]="!hasEdited">変更</button>
+  選択した画像のタグ： <input [(ngModel)]="selectedTag" placeholder="スペース区切りで複数タグ名" />
 </div>
 <hr/>
 <div id="file-list">

--- a/src/app/component/file-storage/file-storage.component.html
+++ b/src/app/component/file-storage/file-storage.component.html
@@ -12,14 +12,14 @@
 </label>
 <hr/>
 <div id="search">
-  検索：  <input [(ngModel)]="searchWord"  placeholder="部分一致で検索" />  <button (click)="searchImageFromTag()">検索</button>
+  検索： <input [(ngModel)]="searchWord" placeholder="部分一致で検索 スペース区切りで複数指定" />
 </div>
 <div id="edit-tag">
-  選択した画像のタグ：  <input [(ngModel)]="selectedImageTag" (input)="changeTagTextBox()" placeholder="" /> <button id="change-tag-button" (click)="changeTag()" [disabled]="!isTagTextBoxChanged">変更</button>
+  選択した画像のタグ： <input [(ngModel)]="selectedTag" placeholder="スペース区切りで複数タグ名" /> <button id="change-tag-button" (click)="changeTag()" [disabled]="!hasEdited">変更</button>
 </div>
 <hr/>
 <div id="file-list">
-  <span *ngFor="let file of fileStorageService.images" class="image">
+  <span *ngFor="let file of images" class="image">
     <img *ngIf="0 < file.url.length" [src]="file.url | safe: 'resourceUrl'" [alt]="file.name" height="120" (click)="onSelectedFile(file)">
     <img *ngIf="file.url.length <= 0" src="assets/images/loading.gif" alt="{{file.name}}">
   </span>

--- a/src/app/component/file-storage/file-storage.component.html
+++ b/src/app/component/file-storage/file-storage.component.html
@@ -15,7 +15,7 @@
   検索： <input [(ngModel)]="searchWord" placeholder="部分一致で検索 スペース区切りで複数指定" />
 </div>
 <div id="edit-tag">
-  選択した画像のタグ： <input [(ngModel)]="selectedTag" placeholder="スペース区切りで複数タグ名" /> <button id="change-tag-button" (click)="changeTag()" [disabled]="!hasEdited">変更</button>
+  選択した画像のタグ： <input [(ngModel)]="editTag" placeholder="スペース区切りで複数タグ名" /> <button id="change-tag-button" (click)="changeTag()" [disabled]="!hasEdited">変更</button>
 </div>
 <hr/>
 <div id="file-list">

--- a/src/app/component/file-storage/file-storage.component.ts
+++ b/src/app/component/file-storage/file-storage.component.ts
@@ -30,22 +30,18 @@ export class FileStorageComponent implements OnInit, OnDestroy, AfterViewInit {
 
   get images(): ImageFile[] {
     if (this.searchWords.length < 1) return ImageStorage.instance.images;
-    return ImageTagList.instance
-      .getTags(this.searchWords)
-      .map(imageTag => ImageStorage.instance.get(imageTag.imageIdentifier))
-      .filter(image => image);
+    return ImageTag.searchImages(this.searchWords);
   }
 
   selectedIdentifier: string = '';
-  get selectedImageTag(): ImageTag { return ImageTagList.instance.getTag(this.selectedIdentifier); }
+  get selectedImageTag(): ImageTag { return ImageTag.getTag(this.selectedIdentifier); }
   get selectedTag(): string { return this.selectedImageTag ? this.selectedImageTag.tag : ''; }
   set selectedTag(selectedTag: string) {
     if (this.selectedImageTag) {
       this.selectedImageTag.tag = selectedTag;
       return;
     }
-    const imageTag = ImageTag.create(this.selectedIdentifier, selectedTag);
-    ImageTagList.instance.add(imageTag);
+    ImageTag.create(this.selectedIdentifier, selectedTag);
   }
 
   constructor(

--- a/src/app/component/file-storage/file-storage.component.ts
+++ b/src/app/component/file-storage/file-storage.component.ts
@@ -33,14 +33,12 @@ export class FileStorageComponent implements OnInit, OnDestroy, AfterViewInit {
   }
 
   selectedIdentifier: string = '';
-  selectedImageTag: ImageTag = null;
-  get selectedTag(): string { return this.selectedImageTag ? this.selectedImageTag.tag : ''; }
-  set selectedTag(selectedTag: string) {
-    if (!this.selectedImageTag) {
-      this.selectedImageTag = ImageTag.create(this.selectedIdentifier);
-    }
-    this.selectedImageTag.tag = selectedTag;
+  get selectedImageTag(): ImageTag {
+    const imageTag = ImageTag.get(this.selectedIdentifier);
+    return imageTag ? imageTag : ImageTag.create(this.selectedIdentifier);
   }
+  get selectedTag(): string { return this.selectedImageTag.tag; }
+  set selectedTag(selectedTag: string) { this.selectedImageTag.tag = selectedTag; }
 
   constructor(
     private changeDetector: ChangeDetectorRef,
@@ -73,6 +71,5 @@ export class FileStorageComponent implements OnInit, OnDestroy, AfterViewInit {
     EventSystem.call('SELECT_FILE', { fileIdentifier: file.identifier }, Network.peerId);
 
     this.selectedIdentifier = file.identifier;
-    this.selectedImageTag = ImageTag.getTag(file.identifier);
   }
 }

--- a/src/app/component/file-storage/file-storage.component.ts
+++ b/src/app/component/file-storage/file-storage.component.ts
@@ -32,13 +32,15 @@ export class FileStorageComponent implements OnInit, OnDestroy, AfterViewInit {
     return ImageTag.searchImages(this.searchWords);
   }
 
-  selectedIdentifier: string = '';
+  selectedFile: ImageFile = null;
+  get isSelected(): boolean { return this.selectedFile != null; }
   get selectedImageTag(): ImageTag {
-    const imageTag = ImageTag.get(this.selectedIdentifier);
-    return imageTag ? imageTag : ImageTag.create(this.selectedIdentifier);
+    if (!this.isSelected) return null;
+    const imageTag = ImageTag.get(this.selectedFile.identifier);
+    return imageTag ? imageTag : ImageTag.create(this.selectedFile.identifier);
   }
-  get selectedTag(): string { return this.selectedImageTag.tag; }
-  set selectedTag(selectedTag: string) { this.selectedImageTag.tag = selectedTag; }
+  get selectedTag(): string { return this.isSelected ? this.selectedImageTag.tag : ''; }
+  set selectedTag(selectedTag: string) { if (this.isSelected) this.selectedImageTag.tag = selectedTag; }
 
   constructor(
     private changeDetector: ChangeDetectorRef,
@@ -70,6 +72,6 @@ export class FileStorageComponent implements OnInit, OnDestroy, AfterViewInit {
     console.log('onSelectedFile', file);
     EventSystem.call('SELECT_FILE', { fileIdentifier: file.identifier }, Network.peerId);
 
-    this.selectedIdentifier = file.identifier;
+    this.selectedFile = file;
   }
 }

--- a/src/app/component/file-storage/file-storage.component.ts
+++ b/src/app/component/file-storage/file-storage.component.ts
@@ -3,7 +3,6 @@ import { AfterViewInit, ChangeDetectionStrategy, ChangeDetectorRef, Component, O
 import { FileArchiver } from '@udonarium/core/file-storage/file-archiver';
 import { ImageFile } from '@udonarium/core/file-storage/image-file';
 import { ImageStorage } from '@udonarium/core/file-storage/image-storage';
-import { ImageTagList } from '@udonarium/image-tag-list';
 import { EventSystem, Network } from '@udonarium/core/system';
 
 import { PanelService } from 'service/panel.service';
@@ -34,14 +33,13 @@ export class FileStorageComponent implements OnInit, OnDestroy, AfterViewInit {
   }
 
   selectedIdentifier: string = '';
-  get selectedImageTag(): ImageTag { return ImageTag.getTag(this.selectedIdentifier); }
+  selectedImageTag: ImageTag = null;
   get selectedTag(): string { return this.selectedImageTag ? this.selectedImageTag.tag : ''; }
   set selectedTag(selectedTag: string) {
-    if (this.selectedImageTag) {
-      this.selectedImageTag.tag = selectedTag;
-      return;
+    if (!this.selectedImageTag) {
+      this.selectedImageTag = ImageTag.create(this.selectedIdentifier);
     }
-    ImageTag.create(this.selectedIdentifier, selectedTag);
+    this.selectedImageTag.tag = selectedTag;
   }
 
   constructor(
@@ -75,5 +73,6 @@ export class FileStorageComponent implements OnInit, OnDestroy, AfterViewInit {
     EventSystem.call('SELECT_FILE', { fileIdentifier: file.identifier }, Network.peerId);
 
     this.selectedIdentifier = file.identifier;
+    this.selectedImageTag = ImageTag.getTag(file.identifier);
   }
 }

--- a/src/app/component/file-storage/file-storage.component.ts
+++ b/src/app/component/file-storage/file-storage.component.ts
@@ -39,8 +39,14 @@ export class FileStorageComponent implements OnInit, OnDestroy, AfterViewInit {
   selectedIdentifier: string = '';
   get selectedImageTag(): ImageTag { return ImageTagList.instance.getTag(this.selectedIdentifier); }
   get selectedTag(): string { return this.selectedImageTag ? this.selectedImageTag.tag : ''; }
-  editTag: string = '';
-  get hasEdited(): boolean { return this.editTag !== this.selectedTag; }
+  set selectedTag(selectedTag: string) {
+    if (this.selectedImageTag) {
+      this.selectedImageTag.tag = selectedTag;
+      return;
+    }
+    const imageTag = ImageTag.create(this.selectedIdentifier, selectedTag);
+    ImageTagList.instance.add(imageTag);
+  }
 
   constructor(
     private changeDetector: ChangeDetectorRef,
@@ -73,15 +79,5 @@ export class FileStorageComponent implements OnInit, OnDestroy, AfterViewInit {
     EventSystem.call('SELECT_FILE', { fileIdentifier: file.identifier }, Network.peerId);
 
     this.selectedIdentifier = file.identifier;
-    this.editTag = this.selectedTag;
-  }
-
-  changeTag() {
-    if (this.selectedImageTag) {
-      this.selectedImageTag.tag = this.editTag;
-      return;
-    }
-    const imageTag = ImageTag.create(this.selectedIdentifier, this.editTag);
-    ImageTagList.instance.add(imageTag);
   }
 }

--- a/src/app/service/save-data.service.ts
+++ b/src/app/service/save-data.service.ts
@@ -31,7 +31,9 @@ export class SaveDataService {
     images = images.concat(this.searchImageFiles(roomXml));
     images = images.concat(this.searchImageFiles(chatXml));
     for (const image of images) {
-      files.push(new File([image.blob], image.identifier + '.' + MimeType.extension(image.blob.type), { type: image.blob.type }));
+      if (image.state === ImageState.COMPLETE) {
+        files.push(new File([image.blob], image.identifier + '.' + MimeType.extension(image.blob.type), { type: image.blob.type }));
+      }
     }
 
     let imageTagXml = this.convertToXml(ImageTagList.create(images));
@@ -48,7 +50,9 @@ export class SaveDataService {
     let images: ImageFile[] = [];
     images = images.concat(this.searchImageFiles(xml));
     for (const image of images) {
-      files.push(new File([image.blob], image.identifier + '.' + MimeType.extension(image.blob.type), { type: image.blob.type }));
+      if (image.state === ImageState.COMPLETE) {
+        files.push(new File([image.blob], image.identifier + '.' + MimeType.extension(image.blob.type), { type: image.blob.type }));
+      }
     }
 
     let imageTagXml = this.convertToXml(ImageTagList.create(images));
@@ -85,7 +89,7 @@ export class SaveDataService {
     }
     for (let identifier in images) {
       let image = images[identifier];
-      if (image && image.state === ImageState.COMPLETE) {
+      if (image) {
         files.push(image);
       }
     }

--- a/src/app/service/save-data.service.ts
+++ b/src/app/service/save-data.service.ts
@@ -11,6 +11,7 @@ import { DataSummarySetting } from '@udonarium/data-summary-setting';
 import { Room } from '@udonarium/room';
 
 import * as Beautify from 'vkbeautify';
+import { ImageTagList } from '@udonarium/image-tag-list';
 
 @Injectable({
   providedIn: 'root'
@@ -21,13 +22,16 @@ export class SaveDataService {
     let files: File[] = [];
     let roomXml = this.convertToXml(new Room());
     let chatXml = this.convertToXml(new ChatTabList());
+    let imageTagXml = this.convertToXml(ImageTagList.instance);
     let summarySetting = this.convertToXml(DataSummarySetting.instance);
     files.push(new File([roomXml], 'data.xml', { type: 'text/plain' }));
     files.push(new File([chatXml], 'chat.xml', { type: 'text/plain' }));
+    files.push(new File([imageTagXml], 'imagetag.xml', { type: 'text/plain' }));
     files.push(new File([summarySetting], 'summary.xml', { type: 'text/plain' }));
 
     files = files.concat(this.searchImageFiles(roomXml));
     files = files.concat(this.searchImageFiles(chatXml));
+    files = files.concat(this.searchImageFiles(imageTagXml));
 
     FileArchiver.instance.save(files, fileName);
   }
@@ -76,7 +80,4 @@ export class SaveDataService {
     }
     return files;
   }
-
-  //NktAts-20190716：ここに、以下のメソッドを足す
-  //イメージタグとXMLを引数として、存在するイメージタグの保存フラグをtrueにするメソッド
 }

--- a/src/app/service/tabletop.service.ts
+++ b/src/app/service/tabletop.service.ts
@@ -19,7 +19,6 @@ import { TextNote } from '@udonarium/text-note';
 
 import { ContextMenuAction } from './context-menu.service';
 import { PointerCoordinate, PointerDeviceService } from './pointer-device.service';
-import { ImageTagList } from '@udonarium/image-tag-list';
 
 type ObjectIdentifier = string;
 type LocationName = string;
@@ -237,10 +236,7 @@ export class TabletopService {
   createTerrain(position: PointerCoordinate): Terrain {
     let url: string = './assets/images/tex.jpg';
     let image: ImageFile = ImageStorage.instance.get(url)
-    if (!image) {
-      image = ImageStorage.instance.add(url);
-      ImageTagList.instance.pushTag(image.identifier,'default , 地形');
-    }
+    if (!image) image = ImageStorage.instance.add(url);
 
     let viewTable = this.tableSelecter.viewTable;
     if (!viewTable) return;
@@ -269,10 +265,7 @@ export class TabletopService {
     diceSymbol.faces.forEach(face => {
       let url: string = `./assets/images/dice/${imagePathPrefix}/${imagePathPrefix}[${face}].png`;
       image = ImageStorage.instance.get(url)
-      if (!image) { 
-        image = ImageStorage.instance.add(url); 
-        ImageTagList.instance.pushTag(image.identifier,'default , ダイス');
-      }
+      if (!image) { image = ImageStorage.instance.add(url); }
       diceSymbol.imageDataElement.getFirstElementByName(face).value = image.identifier;
     });
 
@@ -290,8 +283,7 @@ export class TabletopService {
 
     let back: string = './assets/images/trump/z02.gif';
     if (!ImageStorage.instance.get(back)) {
-      let newImage = ImageStorage.instance.add(back);
-      ImageTagList.instance.pushTag(newImage.identifier,'default , トランプ');
+      ImageStorage.instance.add(back);
     }
 
     let names: string[] = ['c', 'd', 'h', 's'];
@@ -301,8 +293,7 @@ export class TabletopService {
         let trump: string = name + (('00' + i).slice(-2));
         let url: string = './assets/images/trump/' + trump + '.gif';
         if (!ImageStorage.instance.get(url)) {
-          let newImage = ImageStorage.instance.add(url);
-          ImageTagList.instance.pushTag(newImage.identifier,'default , トランプ');
+          ImageStorage.instance.add(url);
         }
         let card = Card.create('カード', url, back);
         cardStack.putOnBottom(card);
@@ -313,8 +304,7 @@ export class TabletopService {
       let trump: string = 'x' + (('00' + i).slice(-2));
       let url: string = './assets/images/trump/' + trump + '.gif';
       if (!ImageStorage.instance.get(url)) {
-        let newImage = ImageStorage.instance.add(url);
-        ImageTagList.instance.pushTag(newImage.identifier,'default , トランプ');
+        ImageStorage.instance.add(url);
       }
       let card = Card.create('カード', url, back);
       cardStack.putOnBottom(card);
@@ -331,12 +321,10 @@ export class TabletopService {
     let bgFileContext = ImageFile.createEmpty('testTableBackgroundImage_image').toContext();
     bgFileContext.url = './assets/images/BG10a_80.jpg';
     testBgFile = ImageStorage.instance.add(bgFileContext);
-    ImageTagList.instance.pushTag(testBgFile.identifier,'default , テーブル')
     //let testDistanceFile: ImageFile = null;
     //let distanceFileContext = ImageFile.createEmpty('testTableDistanceviewImage_image').toContext();
     //distanceFileContext.url = './assets/images/BG00a1_80.jpg';
     //testDistanceFile = ImageStorage.instance.add(distanceFileContext);
-    //ImageTagList.instance.pushTag(testDistanceFile.identifier,'default , テーブル')
     gameTable.name = '最初のテーブル';
     gameTable.imageIdentifier = testBgFile.identifier;
     //gameTable.backgroundImageIdentifier = testDistanceFile.identifier;
@@ -356,7 +344,6 @@ export class TabletopService {
     fileContext = ImageFile.createEmpty('testCharacter_1_image').toContext();
     fileContext.url = './assets/images/mon_052.gif';
     testFile = ImageStorage.instance.add(fileContext);
-    ImageTagList.instance.pushTag(testFile.identifier,'default , キャラクター');
     testCharacter.location.x = 5 * 50;
     testCharacter.location.y = 9 * 50;
     testCharacter.initialize();
@@ -372,7 +359,6 @@ export class TabletopService {
     fileContext = ImageFile.createEmpty('testCharacter_3_image').toContext();
     fileContext.url = './assets/images/mon_128.gif';
     testFile = ImageStorage.instance.add(fileContext);
-    ImageTagList.instance.pushTag(testFile.identifier,'default , キャラクター');
     testCharacter.location.x = 4 * 50;
     testCharacter.location.y = 2 * 50;
     testCharacter.initialize();
@@ -382,7 +368,6 @@ export class TabletopService {
     fileContext = ImageFile.createEmpty('testCharacter_4_image').toContext();
     fileContext.url = './assets/images/mon_150.gif';
     testFile = ImageStorage.instance.add(fileContext);
-    ImageTagList.instance.pushTag(testFile.identifier,'default , キャラクター');
     testCharacter.location.x = 6 * 50;
     testCharacter.location.y = 11 * 50;
     testCharacter.initialize();
@@ -392,7 +377,6 @@ export class TabletopService {
     fileContext = ImageFile.createEmpty('testCharacter_5_image').toContext();
     fileContext.url = './assets/images/mon_211.gif';
     testFile = ImageStorage.instance.add(fileContext);
-    ImageTagList.instance.pushTag(testFile.identifier,'default , キャラクター');
     testCharacter.location.x = 12 * 50;
     testCharacter.location.y = 12 * 50;
     testCharacter.initialize();
@@ -402,7 +386,6 @@ export class TabletopService {
     fileContext = ImageFile.createEmpty('testCharacter_6_image').toContext();
     fileContext.url = './assets/images/mon_135.gif';
     testFile = ImageStorage.instance.add(fileContext);
-    ImageTagList.instance.pushTag(testFile.identifier,'default , キャラクター');
     testCharacter.initialize();
     testCharacter.location.x = 5 * 50;
     testCharacter.location.y = 13 * 50;

--- a/src/app/service/tabletop.service.ts
+++ b/src/app/service/tabletop.service.ts
@@ -239,7 +239,7 @@ export class TabletopService {
     let image: ImageFile = ImageStorage.instance.get(url)
     if (!image) {
       image = ImageStorage.instance.add(url);
-      ImageTag.create(image.identifier, 'imagetag_tex').tag = 'default 地形';
+      ImageTag.create(image.identifier).tag = 'default 地形';
     }
 
     let viewTable = this.tableSelecter.viewTable;
@@ -271,7 +271,7 @@ export class TabletopService {
       image = ImageStorage.instance.get(url)
       if (!image) {
         image = ImageStorage.instance.add(url);
-        ImageTag.create(image.identifier, `imagetag_dice${imagePathPrefix}_${face}`).tag = 'default ダイス';
+        ImageTag.create(image.identifier).tag = 'default ダイス';
       }
       diceSymbol.imageDataElement.getFirstElementByName(face).value = image.identifier;
     });
@@ -291,7 +291,7 @@ export class TabletopService {
     let back: string = './assets/images/trump/z02.gif';
     if (!ImageStorage.instance.get(back)) {
       const image = ImageStorage.instance.add(back);
-      ImageTag.create(image.identifier, `imagetag_trump_back`).tag = 'default トランプ';
+      ImageTag.create(image.identifier).tag = 'default トランプ';
     }
 
     let names: string[] = ['c', 'd', 'h', 's'];
@@ -302,7 +302,7 @@ export class TabletopService {
         let url: string = './assets/images/trump/' + trump + '.gif';
         if (!ImageStorage.instance.get(url)) {
           const image = ImageStorage.instance.add(url);
-          ImageTag.create(image.identifier, `imagetag_trump_${trump}`).tag = 'default トランプ';
+          ImageTag.create(image.identifier).tag = 'default トランプ';
         }
         let card = Card.create('カード', url, back);
         cardStack.putOnBottom(card);
@@ -314,7 +314,7 @@ export class TabletopService {
       let url: string = './assets/images/trump/' + trump + '.gif';
       if (!ImageStorage.instance.get(url)) {
         const image = ImageStorage.instance.add(url);
-        ImageTag.create(image.identifier, `imagetag_trump_${trump}`).tag = 'default トランプ';
+        ImageTag.create(image.identifier).tag = 'default トランプ';
       }
       let card = Card.create('カード', url, back);
       cardStack.putOnBottom(card);
@@ -331,12 +331,12 @@ export class TabletopService {
     let bgFileContext = ImageFile.createEmpty('testTableBackgroundImage_image').toContext();
     bgFileContext.url = './assets/images/BG10a_80.jpg';
     testBgFile = ImageStorage.instance.add(bgFileContext);
-    ImageTag.create(testBgFile.identifier, 'imagetag_testTableBackgroundImage').tag = 'default テーブル';
+    ImageTag.create(testBgFile.identifier).tag = 'default テーブル';
     //let testDistanceFile: ImageFile = null;
     //let distanceFileContext = ImageFile.createEmpty('testTableDistanceviewImage_image').toContext();
     //distanceFileContext.url = './assets/images/BG00a1_80.jpg';
     //testDistanceFile = ImageStorage.instance.add(distanceFileContext);
-    //ImageTag.create(testBgFile.identifier, 'imagetag_testTableDistanceviewImage').tag = 'default テーブル';
+    //ImageTag.create(testBgFile.identifier).tag = 'default テーブル';
     gameTable.name = '最初のテーブル';
     gameTable.imageIdentifier = testBgFile.identifier;
     //gameTable.backgroundImageIdentifier = testDistanceFile.identifier;
@@ -356,7 +356,7 @@ export class TabletopService {
     fileContext = ImageFile.createEmpty('testCharacter_1_image').toContext();
     fileContext.url = './assets/images/mon_052.gif';
     testFile = ImageStorage.instance.add(fileContext);
-    ImageTag.create(testFile.identifier, 'imagetag_mon_052').tag = 'default キャラクター';
+    ImageTag.create(testFile.identifier).tag = 'default キャラクター';
     testCharacter.location.x = 5 * 50;
     testCharacter.location.y = 9 * 50;
     testCharacter.initialize();
@@ -372,7 +372,7 @@ export class TabletopService {
     fileContext = ImageFile.createEmpty('testCharacter_3_image').toContext();
     fileContext.url = './assets/images/mon_128.gif';
     testFile = ImageStorage.instance.add(fileContext);
-    ImageTag.create(testFile.identifier, 'imagetag_mon_128').tag = 'default キャラクター';
+    ImageTag.create(testFile.identifier).tag = 'default キャラクター';
     testCharacter.location.x = 4 * 50;
     testCharacter.location.y = 2 * 50;
     testCharacter.initialize();
@@ -382,7 +382,7 @@ export class TabletopService {
     fileContext = ImageFile.createEmpty('testCharacter_4_image').toContext();
     fileContext.url = './assets/images/mon_150.gif';
     testFile = ImageStorage.instance.add(fileContext);
-    ImageTag.create(testFile.identifier, 'imagetag_mon_150').tag = 'default キャラクター';
+    ImageTag.create(testFile.identifier).tag = 'default キャラクター';
     testCharacter.location.x = 6 * 50;
     testCharacter.location.y = 11 * 50;
     testCharacter.initialize();
@@ -392,7 +392,7 @@ export class TabletopService {
     fileContext = ImageFile.createEmpty('testCharacter_5_image').toContext();
     fileContext.url = './assets/images/mon_211.gif';
     testFile = ImageStorage.instance.add(fileContext);
-    ImageTag.create(testFile.identifier, 'imagetag_mon_211').tag = 'default キャラクター';
+    ImageTag.create(testFile.identifier).tag = 'default キャラクター';
     testCharacter.location.x = 12 * 50;
     testCharacter.location.y = 12 * 50;
     testCharacter.initialize();
@@ -402,7 +402,7 @@ export class TabletopService {
     fileContext = ImageFile.createEmpty('testCharacter_6_image').toContext();
     fileContext.url = './assets/images/mon_135.gif';
     testFile = ImageStorage.instance.add(fileContext);
-    ImageTag.create(testFile.identifier, 'imagetag_mon_135').tag = 'default キャラクター';
+    ImageTag.create(testFile.identifier).tag = 'default キャラクター';
     testCharacter.initialize();
     testCharacter.location.x = 5 * 50;
     testCharacter.location.y = 13 * 50;

--- a/src/app/service/tabletop.service.ts
+++ b/src/app/service/tabletop.service.ts
@@ -19,6 +19,7 @@ import { TextNote } from '@udonarium/text-note';
 
 import { ContextMenuAction } from './context-menu.service';
 import { PointerCoordinate, PointerDeviceService } from './pointer-device.service';
+import { ImageTag } from '@udonarium/image-tag';
 
 type ObjectIdentifier = string;
 type LocationName = string;
@@ -236,7 +237,10 @@ export class TabletopService {
   createTerrain(position: PointerCoordinate): Terrain {
     let url: string = './assets/images/tex.jpg';
     let image: ImageFile = ImageStorage.instance.get(url)
-    if (!image) image = ImageStorage.instance.add(url);
+    if (!image) {
+      image = ImageStorage.instance.add(url);
+      ImageTag.create(image.identifier, 'imagetag_tex').tag = 'default 地形';
+    }
 
     let viewTable = this.tableSelecter.viewTable;
     if (!viewTable) return;
@@ -265,7 +269,10 @@ export class TabletopService {
     diceSymbol.faces.forEach(face => {
       let url: string = `./assets/images/dice/${imagePathPrefix}/${imagePathPrefix}[${face}].png`;
       image = ImageStorage.instance.get(url)
-      if (!image) { image = ImageStorage.instance.add(url); }
+      if (!image) {
+        image = ImageStorage.instance.add(url);
+        ImageTag.create(image.identifier, `imagetag_dice${imagePathPrefix}_${face}`).tag = 'default ダイス';
+      }
       diceSymbol.imageDataElement.getFirstElementByName(face).value = image.identifier;
     });
 
@@ -283,7 +290,8 @@ export class TabletopService {
 
     let back: string = './assets/images/trump/z02.gif';
     if (!ImageStorage.instance.get(back)) {
-      ImageStorage.instance.add(back);
+      const image = ImageStorage.instance.add(back);
+      ImageTag.create(image.identifier, `imagetag_trump_back`).tag = 'default トランプ';
     }
 
     let names: string[] = ['c', 'd', 'h', 's'];
@@ -293,7 +301,8 @@ export class TabletopService {
         let trump: string = name + (('00' + i).slice(-2));
         let url: string = './assets/images/trump/' + trump + '.gif';
         if (!ImageStorage.instance.get(url)) {
-          ImageStorage.instance.add(url);
+          const image = ImageStorage.instance.add(url);
+          ImageTag.create(image.identifier, `imagetag_trump_${trump}`).tag = 'default トランプ';
         }
         let card = Card.create('カード', url, back);
         cardStack.putOnBottom(card);
@@ -304,7 +313,8 @@ export class TabletopService {
       let trump: string = 'x' + (('00' + i).slice(-2));
       let url: string = './assets/images/trump/' + trump + '.gif';
       if (!ImageStorage.instance.get(url)) {
-        ImageStorage.instance.add(url);
+        const image = ImageStorage.instance.add(url);
+        ImageTag.create(image.identifier, `imagetag_trump_${trump}`).tag = 'default トランプ';
       }
       let card = Card.create('カード', url, back);
       cardStack.putOnBottom(card);
@@ -321,10 +331,12 @@ export class TabletopService {
     let bgFileContext = ImageFile.createEmpty('testTableBackgroundImage_image').toContext();
     bgFileContext.url = './assets/images/BG10a_80.jpg';
     testBgFile = ImageStorage.instance.add(bgFileContext);
+    ImageTag.create(testBgFile.identifier, 'imagetag_testTableBackgroundImage').tag = 'default テーブル';
     //let testDistanceFile: ImageFile = null;
     //let distanceFileContext = ImageFile.createEmpty('testTableDistanceviewImage_image').toContext();
     //distanceFileContext.url = './assets/images/BG00a1_80.jpg';
     //testDistanceFile = ImageStorage.instance.add(distanceFileContext);
+    //ImageTag.create(testBgFile.identifier, 'imagetag_testTableDistanceviewImage').tag = 'default テーブル';
     gameTable.name = '最初のテーブル';
     gameTable.imageIdentifier = testBgFile.identifier;
     //gameTable.backgroundImageIdentifier = testDistanceFile.identifier;
@@ -344,6 +356,7 @@ export class TabletopService {
     fileContext = ImageFile.createEmpty('testCharacter_1_image').toContext();
     fileContext.url = './assets/images/mon_052.gif';
     testFile = ImageStorage.instance.add(fileContext);
+    ImageTag.create(testFile.identifier, 'imagetag_mon_052').tag = 'default キャラクター';
     testCharacter.location.x = 5 * 50;
     testCharacter.location.y = 9 * 50;
     testCharacter.initialize();
@@ -359,6 +372,7 @@ export class TabletopService {
     fileContext = ImageFile.createEmpty('testCharacter_3_image').toContext();
     fileContext.url = './assets/images/mon_128.gif';
     testFile = ImageStorage.instance.add(fileContext);
+    ImageTag.create(testFile.identifier, 'imagetag_mon_128').tag = 'default キャラクター';
     testCharacter.location.x = 4 * 50;
     testCharacter.location.y = 2 * 50;
     testCharacter.initialize();
@@ -368,6 +382,7 @@ export class TabletopService {
     fileContext = ImageFile.createEmpty('testCharacter_4_image').toContext();
     fileContext.url = './assets/images/mon_150.gif';
     testFile = ImageStorage.instance.add(fileContext);
+    ImageTag.create(testFile.identifier, 'imagetag_mon_150').tag = 'default キャラクター';
     testCharacter.location.x = 6 * 50;
     testCharacter.location.y = 11 * 50;
     testCharacter.initialize();
@@ -377,6 +392,7 @@ export class TabletopService {
     fileContext = ImageFile.createEmpty('testCharacter_5_image').toContext();
     fileContext.url = './assets/images/mon_211.gif';
     testFile = ImageStorage.instance.add(fileContext);
+    ImageTag.create(testFile.identifier, 'imagetag_mon_211').tag = 'default キャラクター';
     testCharacter.location.x = 12 * 50;
     testCharacter.location.y = 12 * 50;
     testCharacter.initialize();
@@ -386,6 +402,7 @@ export class TabletopService {
     fileContext = ImageFile.createEmpty('testCharacter_6_image').toContext();
     fileContext.url = './assets/images/mon_135.gif';
     testFile = ImageStorage.instance.add(fileContext);
+    ImageTag.create(testFile.identifier, 'imagetag_mon_135').tag = 'default キャラクター';
     testCharacter.initialize();
     testCharacter.location.x = 5 * 50;
     testCharacter.location.y = 13 * 50;


### PR DESCRIPTION
開発一時凍結中の #74 を引き継いで開発したものです。
元の PR の説明に手を入れる形で、今回の PR を説明します。

テスト環境: http://yoshis-island.net/udondev2/
([develop/1.10.x をマージした後のブランチ](https://github.com/blhsrwznrghfzpr/udonarium/tree/feature/blhsrwznrghfzpr/ImageTag-merged)でビルドをしたもの)

# 元 PR への加筆
## 概要
以下の機能を追加します。
- 「画像」メニューで開く画像一覧画面から、タグを付与・変更することができる機能とタグ検索する機能を追加
- 各種オブジェクトの画像変更画面にタグ検索する機能を追加

## ユーザに見える仕様
1. 「画像」メニューで開く画像一覧画面に、以下を追加
- 「検索」欄（テキスト、テキストボックス、 ~「検索」ボタン~ ）
- 「選択した画像のタグ」欄（テキスト、テキストボックス、 ~「変更」ボタン~ ） ~※ テキストボックスに変更があったときだけ「変更」ボタンを操作可能にする~
2. 各種オブジェクトの画像変更画面に以下を追加
- 「検索」テキストボックス
3. 各画像に、新規情報「タグ」を追加。仕様は以下の通り。
- ~画像や、画像のついたオブジェクトを追加した時は、「画像を追加したプレイヤーのニックネーム」を設定（可否検討中）~
-> 画像追加時には、タグは設定しない。
- １つだけ（,などのセパレータで区切れば、実運用上は複数指定可能）
- 改行不可（改行コードは除去）
4. 「画像」メニューにて、画像を選択する機能を追加。選択した画像のタグを、「選択した画像のタグ」テキストボックスに表示する。

5. 「選択した画像のタグ」欄のテキストボックスにて、変更後のタグを入力 ~しEnter入力 or「変更」ボタンを押下~ すると、画像のタグを変更。タグ更新を他プレイヤーに送信する。

6. 「検索」欄のテキストボックスに検索ワードを入力 ~しEnter入力 or 「検索」ボタンを押下~ すると、検索ワードの部分一致にて画像タグを検索し、該当するものだけを画像一覧に表示する。
-> スペース区切りで複数検索をする。

7. ルームデータを「保存」した場合、付与したタグも保存される。旧ルームデータを読み込んだ時、 ~画像のタグは一律「default」を設定（キャラクターや地形などのオブジェクトにタグは保存しない想定）~
-> 画像のタグは保存時のタグを設定する。キャラクターや地形などののオブジェクト保存時にもタグ情報を保存し、読み込めるようにする。

## 改修内容
- 画像一覧画面と画像選択画面に必要なUIを追加
- ~テキストボックスに変更があったときだけ「変更」ボタンを操作可能にするUI仕様追加~
-> 変更は即時反映にしたため不要
- タグを保持するための新規クラスを追加
- 必要なクラスに、新規クラスの保持やインポートを指定
- ~新規画像追加時に、新たな画像タグを付与する機能追加~
-> 新規画像追加時は画像タグを生成しない（※理由は後述）
- 画像一覧画面に、画像を選択する機能と、選択したときに画像に対応するタグを表示する機能を追加
- 画像一覧画面から入力されたときに、タグを変更する機能を追加
- 画像追加時・タグ変更時にタグを他プレイヤーに送信する機能追加
- 画像一覧画面と画像選択画面に、タグで検索ワードの部分一致によって画像を検索する機能と、画像一覧を更新する機能を追加
- ルームデータにタグを保存する機能追加
- ルームデータを読み込んだ時、各画像のタグを読み込む機能を追加


# 実装の詳細
~※実装方針が二転三転してるので、コミットログは追いづらいです。すいません……~

## 画像と画像タグの対応付け
> - ~新規画像追加時に、新たな画像タグを付与する機能追加~
> -> 新規画像追加時は画像タグを生成しない（※理由は後述）

画像追加時の処理は src/app/class/core/ 以下の `FileArchiver` クラスや `ImageStorage` クラスなどに実装されているが、
その前後に処理を挟み込むか `EventSystem` を利用するかしないと、画像追加時に必ず画像タグを生成できなさそうだった。

src/app/class/core/ 内から src/app/class 以下の実装を呼び出すことに抵抗があったのと、
EventSystem に新しいイベントを追加するのには気が引けたため、必ず画像タグを生成するのは断念した。

一度タグを設定した画像には画像タグが紐づくように実装している。
画像タグの identifier を画像の imageIdentifier から生成するようにして、1対1の関係を維持している。

また、画像追加時にタグを生成できないため、
> - ~画像や、画像のついたオブジェクトを追加した時は、「画像を追加したプレイヤーのニックネーム」を設定（可否検討中）~

する機能の実装は断念している


## ImageTagList を保存・読み込みのみのクラスに
元 PR では ImageTagList が ImageTag の管理をするようになっていたが、
ImageTag の identifier を imaegIdentifier から生成するようにしたため、
ImageTag の管理が不要になった。

そのため、保存と読み込み時のみ ImageTagList は使われる（ Room や ChatTab と似た用途）


# この PR の今後
勝手に開発を引き継いだので、こういうときに PR は別にした方がいいのかわからなかったのですが、
元の仕様を大いに参考にして実装したため、元 PR の #74 に反映できるように
NktAts:feature/NktAts/ImageTag への PR にしています。

この PR を merge する場合、 merge する前に一度 develop/1.10.x ブランチに rebase してほしいです。
（申し訳ないことに develop/1.10.x の変更と conflict を起こしてしまっているため、
rebase 後に conflict を解消します）

@NktAts さんに #74 をどうこうするつもりがなければ、こちらで PR を新しく立てます。
